### PR TITLE
IPv6 Address Parsing

### DIFF
--- a/build_bind.inc.php
+++ b/build_bind.inc.php
@@ -434,6 +434,7 @@ EOF
         }
 
         if ($dnsrecord['type'] == 'PTR') {
+            
             // Find the interface record
             list($status, $rows, $interface) = ona_get_interface_record(array('id' => $dnsrecord['interface_id']));
             if ($status or !$rows) {
@@ -445,6 +446,18 @@ EOF
             // Get the name info that the cname points to
             list($status, $rows, $ptr) = ona_get_dns_record(array('id' => $dnsrecord['dns_id']), '');
 
+            // Set the correct reverse zone, depending on the record
+            // type of the interface address
+            $regex = '/^(((?=(?>.*?(::))(?!.+\3)))\3?|([\dA-F]{1,4}(\3|:(?!$)|$)|\2))(?4){5}((?4){2}|(25[0-5]|(2[0-4]|1\d|[1-9])?\d)(\.(?7)){3})\z/i';
+            if (preg_match($regex, $interface['ip_addr_text'])) {
+              $rev_zone = ".ip6.arpa.";
+            }
+            else {
+              $rev_zone = ".in-addr.arpa.";
+            }
+
+            $text .= ";" . $interface['ip_addr_text'] . "\n";
+
             // If this is a delegation domain, find the subnet cidr
             if ($ptrdelegation) {
                 list($status, $rows, $subnet) = ona_get_subnet_record(array('id' => $interface['subnet_id']));
@@ -454,7 +467,7 @@ EOF
                 $ip_remainder  = substr($ip_last, strpos($ip_last,'.')).'.in-addr.arpa.';
                 $text .= sprintf("%-50s %-8s IN  %-8s %s.%-30s %s\n" ,$ip_last_digit.'-'.ip_mangle($subnet['ip_mask'],'cidr').$ip_remainder,$dnsrecord['ttl'],$dnsrecord['type'],$ptr['name'],$ptr['domain_fqdn'].'.',$dnsrecord['notes']);
             } else {
-                $text .= sprintf("%-50s %-8s IN  %-8s %s.%-30s %s\n" ,ip_mangle($interface['ip_addr'],'flip').'.in-addr.arpa.',$dnsrecord['ttl'],$dnsrecord['type'],$ptr['name'],$ptr['domain_fqdn'].'.',$dnsrecord['notes']);
+                $text .= sprintf("%-50s %-8s IN  %-8s %s.%-30s %s\n" ,ip_mangle($interface['ip_addr'],'flip').$rev_zone,$dnsrecord['ttl'],$dnsrecord['type'],$ptr['name'],$ptr['domain_fqdn'].'.',$dnsrecord['notes']);
             }
         }
 


### PR DESCRIPTION
You probably have a better idea of how to do this, but I would like to add IPv6 support to the Bind record generator. As far as I can tell ONA does not flag IPv6 addresses (using the IPv6 branch of the ona master on GitHub). So I have added a regex to do an address check, before adding either 'A' or 'AAAA' to the zone record. This should also be safe for IPv4 only zones, and doesn't require an further changes to the ona database.
