### PR TITLE
Problem with the build_bind config race

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install
   * Ensure you have the following prerequisites installed:
     * A BIND DNS server. It is not required to be on the same host as the ONA system.
     * `sendEmail` for notification messages. [Download here](http://caspian.dotconf.net/menu/Software/SendEmail/) or use the package from your distribution.
-    * A functioning dcm.pl install on your DHCP server.
+    * A functioning dcm.pl install on your DNS server.
   * Download the archive and place it in your $ONABASE/www/local/plugins directory, the directory must be named `build_bind`
   * Make the plugin directory owned by your webserver user I.E.: `chown -R www-data /opt/ona/www/local/plugins/build_bind`
   * From within the GUI, click _Plugins->Manage Plugins_ while logged in as an admin user

--- a/build_bind
+++ b/build_bind
@@ -106,9 +106,13 @@ Usage: $(basename $0) [-c] [-s <FQDN>] [-b] [-t] [-d]
   -d     Enable debug output
 "
 
-while getopts "c:sbtd" options; do
+# include a default configuration file if present to prevent settings from being
+# overwritten whenever the build_bind script is being updated
+[ ! -r "${LOCALCONF}" ] || source "${LOCALCONF}"
+
+while getopts "c:s:btd" options; do
   case $options in
-    c ) LOCALCONF=$OPTARG;;
+    c ) LOCALCONF1=$OPTARG;;
     s ) SRV_FQDN=$OPTARG;;
     b ) BATCHMODE=1;;
     t ) FOOTERS=1;;
@@ -122,7 +126,7 @@ done
 
 # include a local configuration file if present to prevent settings from being
 # overwritten whenever the build_bind script is being updated
-[ ! -r "${LOCALCONF}" ] || source "${LOCALCONF}"
+[ ! -r "${LOCALCONF1}" ] || source "${LOCALCONF1}"
 
 # This will log a message in a standardized way
 # Its job is simple.. take the message that was passed in and log it via some mechanism.


### PR DESCRIPTION
Variables provided by command line had been overwritten as the defaults from config file where loaded after.
This is not a perfect solution, but should work in most cases. There is still problem when you use this mixture
bash build_bind -s mydns.server.com -c ~/myOwnBuldBindConfig.conf

If $SRV_FQDN is defined in ~/myOwnBuldBindConfig.conf it will override the -s from command line.

The other one is minor typo on README.md.
Sorry to put those two together, still learning.